### PR TITLE
Add interactive suggestion REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 An application for Arabic Plurals
+
+## Interactive Suggestions
+
+This repository now includes `interactive_suggest.py`, a simple REPL that
+shows word suggestions as you type. After you have entered three or more
+characters, any previously used identifiers that start with those characters
+will appear below the prompt in blue.
+
+Run it with:
+
+```bash
+python3 interactive_suggest.py
+```
+
+Exit with `exit()` or `quit()`.

--- a/interactive_suggest.py
+++ b/interactive_suggest.py
@@ -1,0 +1,39 @@
+import re
+from prompt_toolkit import PromptSession
+from prompt_toolkit.application import run_in_terminal
+from prompt_toolkit.formatted_text import HTML
+
+
+tokens = set()
+
+
+def extract_tokens(line):
+    for token in re.findall(r"[A-Za-z_][A-Za-z0-9_]*", line):
+        tokens.add(token)
+
+
+def bottom_toolbar():
+    text = session.default_buffer.document.text_before_cursor
+    if len(text) >= 3:
+        suggestions = [w for w in sorted(tokens) if w.startswith(text) and w != text]
+        if suggestions:
+            return HTML('<skyblue>' + ' '.join(suggestions[:5]) + '</skyblue>')
+    return ''
+
+
+session = PromptSession(bottom_toolbar=bottom_toolbar)
+
+
+def main():
+    while True:
+        try:
+            line = session.prompt('>>> ', refresh_interval=0.5)
+            if line.strip() in {'exit()', 'quit()'}:
+                break
+            extract_tokens(line)
+        except (EOFError, KeyboardInterrupt):
+            break
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a simple REPL showing suggestions below the prompt
- document how to run the new script

## Testing
- `python3 interactive_suggest.py <<'EOF'
print('hello')
exit()
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68579d7faa248329bd269ec1445bcd79